### PR TITLE
Tabelle für verteilte Studenten auf Module

### DIFF
--- a/src/main/java/mops/controller/VerteilerController.java
+++ b/src/main/java/mops/controller/VerteilerController.java
@@ -21,13 +21,15 @@ public class VerteilerController {
   private transient ModulService modulService;
   private transient DozentPraeferenzService dozentPraeferenzService;
   private transient ZyklusDirigentService zyklusDirigentService;
+  private transient VerteilerService verteilerService;
 
   public VerteilerController(BewerberService bewerberService, ModulService modulService,
-      DozentPraeferenzService dozentPraeferenzService, ZyklusDirigentService zyklusDirigentService) {
+      DozentPraeferenzService dozentPraeferenzService, ZyklusDirigentService zyklusDirigentService, VerteilerService verteilerService) {
     this.bewerberService = bewerberService;
     this.modulService = modulService;
     this.dozentPraeferenzService = dozentPraeferenzService;
     this.zyklusDirigentService = zyklusDirigentService;
+    this.verteilerService = verteilerService;
   }
 
   @Secured(ROLE_VERTEILER)
@@ -47,6 +49,8 @@ public class VerteilerController {
     model.addAttribute("verteilerPhase", zyklusDirigentService.getVerteilerPhase());
     model.addAttribute("dozentPhase", zyklusDirigentService.getDozentenPhase());
     model.addAttribute("bewerberPhase", zyklusDirigentService.getBewerbungsPhase());
+
+    model.addAttribute("modulMitZugewiesende", verteilerService.getListModulMitAnzahlVerteilten(modulService.findAllModule()));
 
     return "verteiler/verteiler";
   }
@@ -68,6 +72,9 @@ public class VerteilerController {
     model.addAttribute("dozentPhase", zyklusDirigentService.getDozentenPhase());
     model.addAttribute("bewerberPhase", zyklusDirigentService.getBewerbungsPhase());
 
+    model.addAttribute("modulMitZugewiesende", verteilerService.getListModulMitAnzahlVerteilten(modulService.findAllModule()));
+
+
     return "verteiler/verteiler";
   }
 
@@ -87,6 +94,9 @@ public class VerteilerController {
     model.addAttribute("verteilerPhase", zyklusDirigentService.getVerteilerPhase());
     model.addAttribute("dozentPhase", zyklusDirigentService.getDozentenPhase());
     model.addAttribute("bewerberPhase", zyklusDirigentService.getBewerbungsPhase());
+
+    model.addAttribute("modulMitZugewiesende", verteilerService.getListModulMitAnzahlVerteilten(modulService.findAllModule()));
+
 
     return "verteiler/verteiler";
   }

--- a/src/main/java/mops/domain/models/ModuleMitVerteiltenAnzahl.java
+++ b/src/main/java/mops/domain/models/ModuleMitVerteiltenAnzahl.java
@@ -1,0 +1,15 @@
+package mops.domain.models;
+
+import lombok.Data;
+
+@Data
+public class ModuleMitVerteiltenAnzahl {
+  private Modul modul;
+  private int anzhalVerteilte;
+
+  public ModuleMitVerteiltenAnzahl(Modul modul, int anzhalVerteilte){
+    this.modul = modul;
+    this.anzhalVerteilte = anzhalVerteilte;
+  }
+
+}

--- a/src/main/java/mops/domain/repositories/VerteilungRepo.java
+++ b/src/main/java/mops/domain/repositories/VerteilungRepo.java
@@ -1,0 +1,12 @@
+package mops.domain.repositories;
+
+import javax.persistence.OneToMany;
+import mops.domain.database.dto.VerteilungDTO;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VerteilungRepo extends CrudRepository<VerteilungDTO,Long> {
+
+  int countVerteilungDTOByDozentKennungEquals(String dozentKennung);
+}

--- a/src/main/java/mops/services/VerteilerService.java
+++ b/src/main/java/mops/services/VerteilerService.java
@@ -14,6 +14,7 @@ public class VerteilerService {
   @Autowired
   private transient VerteilungRepo verteilungRepo;
 
+  @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
   public List<ModuleMitVerteiltenAnzahl> getListModulMitAnzahlVerteilten(List<Modul> listModul){
     List<ModuleMitVerteiltenAnzahl> moduleMitVerteiltenAnzahlList = new LinkedList<>();
     for(Modul modul : listModul){

--- a/src/main/java/mops/services/VerteilerService.java
+++ b/src/main/java/mops/services/VerteilerService.java
@@ -1,0 +1,35 @@
+package mops.services;
+
+import java.util.LinkedList;
+import java.util.List;
+import mops.domain.models.Modul;
+import mops.domain.models.ModuleMitVerteiltenAnzahl;
+import mops.domain.repositories.VerteilungRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VerteilerService {
+
+  @Autowired
+  private transient VerteilungRepo verteilungRepo;
+
+  public List<ModuleMitVerteiltenAnzahl> getListModulMitAnzahlVerteilten(List<Modul> listModul){
+    List<ModuleMitVerteiltenAnzahl> moduleMitVerteiltenAnzahlList = new LinkedList<>();
+    for(Modul modul : listModul){
+      ModuleMitVerteiltenAnzahl moduleMitVerteiltenAnzahl = buildModulMitAnzahlVerteilten(modul);
+      moduleMitVerteiltenAnzahlList.add(moduleMitVerteiltenAnzahl);
+    }
+    return moduleMitVerteiltenAnzahlList;
+  }
+
+  private ModuleMitVerteiltenAnzahl buildModulMitAnzahlVerteilten(Modul modul) {
+    int anzahlVerteilte = verteilungRepo.countVerteilungDTOByDozentKennungEquals(modul.getDozent().getDozentMail());
+    return new ModuleMitVerteiltenAnzahl(modul, anzahlVerteilte);
+  }
+
+
+
+
+
+}

--- a/src/main/resources/templates/verteiler/verteiler.html
+++ b/src/main/resources/templates/verteiler/verteiler.html
@@ -14,6 +14,8 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+
+
   </th:block>
 </head>
 
@@ -32,7 +34,7 @@
         <a th:href="@{./verteilte}">Verteilte Bewerbungen</a>
       </li>
       <li>
-        <a href="/logout">Logout</a>
+        <a href="https://keycloak.cs.hhu.de/auth/realms/MOPS/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fbewerbung1%2F">Logout</a>
       </li>
     </ul>
   </nav>
@@ -58,9 +60,28 @@
     </div>
   </div>
 
-  <div class="container pt-3" th:unless="${verteilerPhase}">
+  <div class="container pt3" th:unless="${verteilerPhase}">
     <div class="alert alert-warning">
       Aktuell können Sie keine Bewerbungen verteilen. Bitte stellen Sie oben die Verteilerphase ein.
+    </div>
+  </div>
+
+  <div class="container pt3" style=" position: sticky; top:29px; z-index: 10"  th:if="${verteilerPhase}">
+    <div class="col-12 shadow p-3 mb-5 bg-light rounded">
+      <div class="card-body">
+        <table class="table table-bordered">
+          <thead class="thead-dark">
+            <tr>
+              <th scope="col" th:each="modulName : ${modulMitZugewiesende}" th:text="${modulName.modul.modulName}" style="font-weight: bolder"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td th:each="anzahl : ${modulMitZugewiesende}" th:text="${anzahl.anzhalVerteilte}"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 

--- a/src/main/resources/templates/verteiler/verteiler.html
+++ b/src/main/resources/templates/verteiler/verteiler.html
@@ -66,11 +66,11 @@
     </div>
   </div>
 
-  <div class="container pt3" style=" position: sticky; top:29px; z-index: 10"  th:if="${verteilerPhase}">
+  <div class="container pt3" style="position: sticky; top:29px; z-index: 10"  th:if="${verteilerPhase}">
     <div class="col-12 shadow p-3 mb-5 bg-light rounded">
       <div class="card-body">
         <table class="table table-bordered">
-          <thead class="thead-dark">
+          <thead class="thead-light">
             <tr>
               <th scope="col" th:each="modulName : ${modulMitZugewiesende}" th:text="${modulName.modul.modulName}" style="font-weight: bolder"></th>
             </tr>


### PR DESCRIPTION
In der Verteileransicht wird eine Tabelle angezeigt, in der die Anzahl der bereits zugeordneten Bewerber pro Modul anzeigt.